### PR TITLE
feat: rename multiple files while copying using glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ and finally the third and last argument is a callback function which is executed
     up: number,         // -u value
     exclude: string,    // exclude pattern
     all: bool,	        // include dot files
-    follow: bool,	      // follow symlinked directories when expanding ** patterns
+    follow: bool,       // follow symlinked directories when expanding ** patterns
     error: bool         // raise errors if no files copied
     rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
 }

--- a/README.md
+++ b/README.md
@@ -202,6 +202,6 @@ and finally the third and last argument is a callback function which is executed
     all: bool,	        // include dot files
     follow: bool,       // follow symlinked directories when expanding ** patterns
     error: bool         // raise errors if no files copied
-    rename?: (src, dest) => string;  // callback to transform the destination filename(s)
+    rename: (src, dest) => string;  // callback to transform the destination filename(s)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ npm install native-copyfiles -D
     -E, --error    throw error if nothing is copied                          [boolean]
     -V, --verbose  print more information to console                         [boolean]
     -F, --follow   follow symbolic links                                     [boolean]
-    -v, --version  Show version number                                       [boolean]
-    -h, --help     Show help                                                 [boolean]
+    -v, --version  show version number                                       [boolean]
+    -h, --help     show help                                                 [boolean]
 ```
 
 > [!NOTE]
@@ -122,6 +122,63 @@ copyfiles input/original.txt output/renamed.txt
 
 If the destination path is a directory, the file will be copied into that directory as usual. If the destination path is a filename, the file will be copied and renamed.
 
+---
+
+### Rename Multiple Files During Copy
+
+#### 1. Rename Using Glob Patterns
+
+You can use a wildcard (`*`) in the destination to rename files dynamically. For example, to copy all `.css` files and change their extension to `.scss`:
+
+```bash
+copyfiles "input/**/*.css" "output/*.scss"
+```
+
+This will copy:
+
+- `input/foo.css` → `output/foo.scss`
+- `input/bar/baz.css` → `output/bar/baz.scss`
+
+The `*` in the destination is replaced with the base filename from the source.  
+You can combine this with `--flat` or `--up` to control the output structure.
+
+#### 2. Rename Using a Callback (JavaScript API)
+
+For advanced renaming, you can use the `rename` callback option in the API.  
+This function receives the source and destination path and should return the new destination path.
+
+**Example: Change extension to `.scss` using a callback**
+
+```js
+import { copyfiles } from 'native-copyfiles';
+
+copyfiles(['input/**/*.css', 'output'], {
+  flat: true,
+  rename: (src, dest) => dest.replace(/\.css$/, '.scss')
+}, (err) => {
+  // All files like input/foo.css → output/foo.scss
+});
+```
+
+**Example: Prefix all filenames with `renamed-` but keep the extension**
+
+```js
+copyfiles(['input/**/*.css', 'output'], {
+  up: 1,
+  rename: (src, dest) => dest.replace(/([^/\\]+)\.css$/, 'renamed-$1.css')
+}, (err) => {
+  // input/foo.css → output/renamed-foo.css
+  // input/bar/baz.css → output/bar/renamed-baz.css
+});
+```
+
+The `rename` callback gives you full control over the output filename and path.
+
+> **Tip:**  
+> You can use either the glob pattern approach or the `rename` callback, or even combine them for advanced scenarios!
+
+---
+
 ### JavaScript API
 
 ```js
@@ -140,7 +197,8 @@ and finally the third and last argument is a callback function which is executed
 	up: number,       // -u value
 	exclude: string,  // exclude pattern
 	all: bool,	  // include dot files
-	follow: bool,	  // Follow symlinked directories when expanding ** patterns
+	follow: bool,	  // follow symlinked directories when expanding ** patterns
 	error: bool       // raise errors if no files copied
+  rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ and finally the third and last argument is a callback function which is executed
 
 ```js
 {
-	verbose: bool,    // enable debug messages
-	up: number,       // -u value
-	exclude: string,  // exclude pattern
-	all: bool,	  // include dot files
-	follow: bool,	  // follow symlinked directories when expanding ** patterns
-	error: bool       // raise errors if no files copied
-  rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
+  verbose: bool,    // enable debug messages
+  up: number,       // -u value
+  exclude: string,  // exclude pattern
+  all: bool,	  // include dot files
+  follow: bool,	  // follow symlinked directories when expanding ** patterns
+  error: bool       // raise errors if no files copied
+	rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ and finally the third and last argument is a callback function which is executed
 
 ```js
 {
-  verbose: bool,    // enable debug messages
-  up: number,       // -u value
-  exclude: string,  // exclude pattern
-  all: bool,	  // include dot files
-  follow: bool,	  // follow symlinked directories when expanding ** patterns
-  error: bool       // raise errors if no files copied
-	rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
+    verbose: bool,    // enable debug messages
+    up: number,       // -u value
+    exclude: string,  // exclude pattern
+    all: bool,	  // include dot files
+    follow: bool,	  // follow symlinked directories when expanding ** patterns
+    error: bool       // raise errors if no files copied
+    rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -199,6 +199,6 @@ and finally the third and last argument is a callback function which is executed
     all: bool,	        // include dot files
     follow: bool,       // follow symlinked directories when expanding ** patterns
     error: bool         // raise errors if no files copied
-    rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
+    rename?: (src, dest) => string;  // callback to transform the destination filename(s)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ The `rename` callback gives you full control over the output filename and path.
 > **Tip:**  
 > You can use either the glob pattern approach or the `rename` callback, or even combine them for advanced scenarios!
 
+> [!NOTE]
+> If you use both a destination glob pattern (e.g. `output/*.ext`) and a `rename` callback, the glob pattern is applied first and then the `rename` callback is executed last on the computed destination path. This allows you to combine both features for advanced renaming scenarios.
+
 ---
 
 ### JavaScript API

--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ and finally the third and last argument is a callback function which is executed
 
 ```js
 {
-    verbose: bool,    // enable debug messages
-    up: number,       // -u value
-    exclude: string,  // exclude pattern
-    all: bool,	  // include dot files
-    follow: bool,	  // follow symlinked directories when expanding ** patterns
-    error: bool       // raise errors if no files copied
+    verbose: bool,      // enable debug messages
+    up: number,         // -u value
+    exclude: string,    // exclude pattern
+    all: bool,	        // include dot files
+    follow: bool,	      // follow symlinked directories when expanding ** patterns
+    error: bool         // raise errors if no files copied
     rename?: (src: string, dest: string) => string;  // callback to transform the destination filename(s)
 }
 ```

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdir, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readdir, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { createDir } from '../index';
@@ -62,17 +62,17 @@ describe('copyfiles', () => {
             setTimeout(check, 50);
             return;
           }
-          readdir('output2/input2', (err, files) => {
-            try {
-              expect(err).toBeNull();
+          try {
+            setTimeout(() => {
+              const files = readdirSync('output2/input2');
               expect(files).toEqual(['a.txt', 'b.txt']);
               exitSpy.mockRestore();
               done();
-            } catch (e) {
-              exitSpy.mockRestore();
-              done(e);
-            }
-          });
+            }, 50);
+          } catch (e) {
+            exitSpy.mockRestore();
+            done(e);
+          }
         };
         check();
       })

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -415,6 +415,7 @@ describe('copyfiles', () => {
   test('copies and renames files, using --up:1 option, from subfolders using wildcard in destination with .scss extension', () => new Promise((done: any) => {
     // Setup: create input files in subfolders
     createDir('input/sub1');
+    createDir('input/sub2');
     createDir('input/sub2/deep1');
     writeFileSync('input/root.css', '.root { color: black }');
     writeFileSync('input/sub1/input1.css', 'h1 { color: red }');

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, readdir, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdir, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { Readable } from 'node:stream';
 import { globSync } from 'tinyglobby';
 import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -13,7 +14,6 @@ vi.mock('node:fs', async () => {
     ...actual,
     createReadStream: (...args: any[]) => {
       if (shouldMockReadError) {
-        const { Readable } = require('node:stream');
         const stream = new Readable({ read() { } });
         setImmediate(() => stream.emit('error', error));
         return stream;
@@ -24,7 +24,7 @@ vi.mock('node:fs', async () => {
   };
 });
 
-async function cleanupFolders() {
+function cleanupFolders() {
   try {
     rmSync('input', { recursive: true, force: true });
     rmSync('output', { recursive: true, force: true });
@@ -32,12 +32,12 @@ async function cleanupFolders() {
 }
 
 describe('copyfiles', () => {
-  afterEach(async () => {
-    await cleanupFolders();
+  afterEach(() => {
+    cleanupFolders();
   });
 
-  afterAll(async () => {
-    await cleanupFolders();
+  afterAll(() => {
+    cleanupFolders();
   });
 
   beforeEach(() => {
@@ -62,8 +62,8 @@ describe('copyfiles', () => {
     writeFileSync('input/a.txt', 'a');
     writeFileSync('input/b.txt', 'b');
     writeFileSync('input/c.js', 'c');
-    copyfiles(['input/*.txt', 'output'], {}, (err) => {
-      readdir('output/input', async (err, files) => {
+    copyfiles(['input/*.txt', 'output'], {}, () => {
+      readdir('output/input', async (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         done();
       });
@@ -76,8 +76,8 @@ describe('copyfiles', () => {
     });
     writeFileSync('input/b.txt', 'b');
     writeFileSync('input/c.js', 'c');
-    copyfiles(['input/*.txt', 'output'], {}, (err) => {
-      readdir('output/input', (err, files) => {
+    copyfiles(['input/*.txt', 'output'], {}, () => {
+      readdir('output/input', (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         //  'correct mode'
         // expect(statSync('output/input/a.txt').mode).toBe(33261);
@@ -94,7 +94,7 @@ describe('copyfiles', () => {
     copyfiles(['input/*.txt', 'output'], {
       exclude: ['**/*.js.txt', '**/*.ps.txt']
     }, (err) => {
-      readdir('output/input', (err, files) => {
+      readdir('output/input', (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         done();
       });
@@ -113,8 +113,8 @@ describe('copyfiles', () => {
     writeFileSync('input/a.txt', 'a');
     writeFileSync('input/b.txt', 'b');
     writeFileSync('input/.c.txt', 'c');
-    copyfiles(['input/*.txt', 'output'], { all: true }, (err) => {
-      readdir('output/input', (err, files) => {
+    copyfiles(['input/*.txt', 'output'], { all: true }, () => {
+      readdir('output/input', (_err, files) => {
         expect(files).toEqual(['.c.txt', 'a.txt', 'b.txt']);
         done();
       });
@@ -125,8 +125,8 @@ describe('copyfiles', () => {
     writeFileSync('input/a.txt', 'a');
     writeFileSync('input/b.txt', 'b');
     writeFileSync('input/c.js', 'c');
-    copyfiles(['input/*.txt', 'output'], { up: 1 }, (err) => {
-      readdir('output', (err, files) => {
+    copyfiles(['input/*.txt', 'output'], { up: 1 }, () => {
+      readdir('output', (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         done();
       });
@@ -134,12 +134,14 @@ describe('copyfiles', () => {
   }));
 
   test('with up true', () => new Promise((done: any) => {
+    createDir('input/deep');
     writeFileSync('input/a.txt', 'a');
     writeFileSync('input/b.txt', 'b');
     writeFileSync('input/c.js', 'c');
-    copyfiles(['input/*.txt', 'output'], { up: true }, (err) => {
-      readdir('output', (err, files) => {
-        expect(files).toEqual(['a.txt', 'b.txt']);
+    writeFileSync('input/deep/d.txt', 'd');
+    copyfiles(['input/**/*.txt', 'output'], { up: true }, () => {
+      readdir('output', (_err, files) => {
+        expect(files).toEqual(['a.txt', 'b.txt', 'd.txt']);
         done();
       });
     });
@@ -149,8 +151,8 @@ describe('copyfiles', () => {
     writeFileSync('input/other/a.txt', 'a');
     writeFileSync('input/other/b.txt', 'b');
     writeFileSync('input/other/c.js', 'c');
-    copyfiles(['input/**/*.txt', 'output'], { up: 2 }, (err) => {
-      readdir('output', (err, files) => {
+    copyfiles(['input/**/*.txt', 'output'], { up: 2 }, () => {
+      readdir('output', (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         done();
       });
@@ -173,8 +175,8 @@ describe('copyfiles', () => {
     writeFileSync('input/other/a.txt', 'a');
     writeFileSync('input/b.txt', 'b');
     writeFileSync('input/other/c.js', 'c');
-    copyfiles(['input/**/*.txt', 'output'], { flat: true }, (err) => {
-      readdir('output', (err, files) => {
+    copyfiles(['input/**/*.txt', 'output'], { flat: true }, () => {
+      readdir('output', (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         done();
       });
@@ -188,7 +190,7 @@ describe('copyfiles', () => {
       writeFileSync('input/origin/inner/a.txt', 'a');
       writeFileSync('input/origin/inner/b.txt', 'b');
       symlinkSync('origin', 'input/dest');
-      copyfiles(['input/**/*.txt', 'output'], { up: 1, follow: true }, (err) => {
+      copyfiles(['input/**/*.txt', 'output'], { up: 1, follow: true }, () => {
         const files = globSync('output/**/*.txt');
         expect(new Set(files)).toEqual(new Set(['output/a.txt', 'output/b.txt']));
       });
@@ -200,8 +202,8 @@ describe('copyfiles', () => {
     writeFileSync('input/other/a.txt', 'a');
     writeFileSync('input/b.txt', 'b');
     writeFileSync('input/other/c.js', 'c');
-    copyfiles(['input/**/*.txt', 'output'], { flat: true, verbose: true }, (err) => {
-      readdir('output', (err, files) => {
+    copyfiles(['input/**/*.txt', 'output'], { flat: true, verbose: true }, () => {
+      readdir('output', (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         const globCall = logSpy.mock.calls.find(call => call[0] === 'glob found');
         expect(globCall).toBeTruthy();
@@ -306,8 +308,8 @@ describe('copyfiles', () => {
     writeFileSync('input/other/a.txt', 'a');
     writeFileSync('input/other/b.txt', 'b');
     writeFileSync('input/other/c.js', 'c');
-    copyfiles(['input/**/*.txt', 'output'], { up: 2, verbose: true }, (err) => {
-      readdir('output', (err, files) => {
+    copyfiles(['input/**/*.txt', 'output'], { up: 2, verbose: true }, () => {
+      readdir('output', (_err, files) => {
         expect(files).toEqual(['a.txt', 'b.txt']);
         expect(logSpy).toHaveBeenCalledWith('glob found', ['input/other/a.txt', 'input/other/b.txt']);
         expect(logSpy).toHaveBeenCalledWith('copy:', { from: 'input/other/a.txt', to: 'output/a.txt' });
@@ -322,10 +324,9 @@ describe('copyfiles', () => {
     writeFileSync('input/.env.production', 'SOME=VALUE');
     copyfiles(['input/.env.production', 'output/.env'], {}, (err) => {
       expect(err).toBeUndefined();
-      readdir('output', (err, files) => {
+      readdir('output', (_err, files) => {
         expect(files).toContain('.env');
         // Check file contents
-        const { readFileSync } = require('node:fs');
         const content = readFileSync('output/.env', 'utf8');
         expect(content).toBe('SOME=VALUE');
         done();
@@ -337,14 +338,168 @@ describe('copyfiles', () => {
     writeFileSync('input/original.txt', 'HELLO WORLD');
     copyfiles(['input/original.txt', 'output/renamed.txt'], {}, (err) => {
       expect(err).toBeUndefined();
-      readdir('output', (err, files) => {
+      readdir('output', (_err, files) => {
         expect(files).toContain('renamed.txt');
         // Check file contents
-        const { readFileSync } = require('node:fs');
         const content = readFileSync('output/renamed.txt', 'utf8');
         expect(content).toBe('HELLO WORLD');
         done();
       });
+    });
+  }));
+
+  test('copies and renames files, using --flat option, from subfolders using wildcard in destination with .scss extension', () => new Promise((done: any) => {
+    // Setup: create input files in subfolders
+    createDir('input/sub1');
+    createDir('input/sub2/deep1');
+    writeFileSync('input/root.css', '.root { color: black }');
+    writeFileSync('input/sub1/input1.css', 'h1 { color: red }');
+    writeFileSync('input/sub2/input2.css', 'h2 { color: blue }');
+    writeFileSync('input/sub2/input3.css', 'h3 { color: green }');
+    writeFileSync('input/sub2/deep1/d1.css', '.d1 { color: yellow }');
+
+    copyfiles(['input/**/*.css', 'output/*.scss'], { flat: true }, (err) => {
+      expect(err).toBeUndefined();
+      const files = readdirSync('output');
+      expect(files).toEqual(expect.arrayContaining([
+        'root.scss', 'input1.scss', 'input2.scss', 'input3.scss', 'd1.scss'
+      ]));
+      expect(readFileSync('output/root.scss', 'utf8')).toBe('.root { color: black }');
+      expect(readFileSync('output/input1.scss', 'utf8')).toBe('h1 { color: red }');
+      expect(readFileSync('output/input2.scss', 'utf8')).toBe('h2 { color: blue }');
+      expect(readFileSync('output/input3.scss', 'utf8')).toBe('h3 { color: green }');
+      expect(readFileSync('output/d1.scss', 'utf8')).toBe('.d1 { color: yellow }');
+      done();
+    });
+  }));
+
+  test('copies and renames files, using --up option, from subfolders using wildcard in destination with .scss extension', () => new Promise((done: any) => {
+    // Setup: create input files in subfolders
+    createDir('input/sub1');
+    createDir('input/sub2/deep1');
+    writeFileSync('input/root.css', '.root { color: black }');
+    writeFileSync('input/sub1/input1.css', 'h1 { color: red }');
+    writeFileSync('input/sub2/input2.css', 'h2 { color: blue }');
+    writeFileSync('input/sub2/input3.css', 'h3 { color: green }');
+    writeFileSync('input/sub2/deep1/d1.css', '.d1 { color: yellow }');
+
+    copyfiles(['input/**/*.css', 'output/*.scss'], {}, (err) => {
+      expect(err).toBeUndefined();
+      expect(readFileSync('output/input/root.scss', 'utf8')).toBe('.root { color: black }');
+      expect(readFileSync('output/input/sub1/input1.scss', 'utf8')).toBe('h1 { color: red }');
+      expect(readFileSync('output/input/sub2/input2.scss', 'utf8')).toBe('h2 { color: blue }');
+      expect(readFileSync('output/input/sub2/input3.scss', 'utf8')).toBe('h3 { color: green }');
+      expect(readFileSync('output/input/sub2/deep1/d1.scss', 'utf8')).toBe('.d1 { color: yellow }');
+      done();
+    });
+  }));
+
+  test('copies and renames files, using --up:1 option, from subfolders using wildcard in destination with .scss extension', () => new Promise((done: any) => {
+    // Setup: create input files in subfolders
+    createDir('input/deep1');
+    writeFileSync('input/input1.css', 'h1 { color: red }');
+    writeFileSync('input/input2.css', 'h2 { color: blue }');
+    writeFileSync('input/input3.css', 'h3 { color: green }');
+    writeFileSync('input/deep1/d1.css', '.d1 { color: yellow }');
+
+    copyfiles(['input/**/*.css', 'output/*.scss'], { up: true }, (err) => {
+      expect(err).toBeUndefined();
+      expect(readFileSync('output/input1.scss', 'utf8')).toBe('h1 { color: red }');
+      expect(readFileSync('output/input2.scss', 'utf8')).toBe('h2 { color: blue }');
+      expect(readFileSync('output/input3.scss', 'utf8')).toBe('h3 { color: green }');
+      expect(readFileSync('output/d1.scss', 'utf8')).toBe('.d1 { color: yellow }');
+      done();
+    });
+  }));
+
+  test('copies and renames files, using --up:1 option, from subfolders using wildcard in destination with .scss extension', () => new Promise((done: any) => {
+    // Setup: create input files in subfolders
+    createDir('input/sub1');
+    createDir('input/sub2/deep1');
+    writeFileSync('input/root.css', '.root { color: black }');
+    writeFileSync('input/sub1/input1.css', 'h1 { color: red }');
+    writeFileSync('input/sub2/input2.css', 'h2 { color: blue }');
+    writeFileSync('input/sub2/input3.css', 'h3 { color: green }');
+    writeFileSync('input/sub2/deep1/d1.css', '.d1 { color: yellow }');
+
+    copyfiles(['input/**/*.css', 'output/*.scss'], { up: 1 }, (err) => {
+      expect(err).toBeUndefined();
+      expect(readFileSync('output/root.scss', 'utf8')).toBe('.root { color: black }');
+      expect(readFileSync('output/sub1/input1.scss', 'utf8')).toBe('h1 { color: red }');
+      expect(readFileSync('output/sub2/input2.scss', 'utf8')).toBe('h2 { color: blue }');
+      expect(readFileSync('output/sub2/input3.scss', 'utf8')).toBe('h3 { color: green }');
+      expect(readFileSync('output/sub2/deep1/d1.scss', 'utf8')).toBe('.d1 { color: yellow }');
+      done();
+    });
+  }));
+
+  test('copies and renames files, using --flat option and rename callback, from subfolders with .scss extension', () => new Promise((done: any) => {
+    // Setup: create input files in subfolders
+    createDir('input/sub1');
+    createDir('input/sub2/deep1');
+    writeFileSync('input/root.css', '.root { color: black }');
+    writeFileSync('input/sub1/input1.css', 'h1 { color: red }');
+    writeFileSync('input/sub2/input2.css', 'h2 { color: blue }');
+    writeFileSync('input/sub2/input3.css', 'h3 { color: green }');
+    writeFileSync('input/sub2/deep1/d1.css', '.d1 { color: yellow }');
+
+    copyfiles(['input/**/*.css', 'output'], {
+      flat: true,
+      rename: (_src, dest) => dest.replace(/\.css$/, '.scss')
+    }, (err) => {
+      expect(err).toBeUndefined();
+      const files = readdirSync('output');
+      expect(files).toEqual(expect.arrayContaining([
+        'root.scss', 'input1.scss', 'input2.scss', 'input3.scss', 'd1.scss'
+      ]));
+      expect(readFileSync('output/root.scss', 'utf8')).toBe('.root { color: black }');
+      expect(readFileSync('output/input1.scss', 'utf8')).toBe('h1 { color: red }');
+      expect(readFileSync('output/input2.scss', 'utf8')).toBe('h2 { color: blue }');
+      expect(readFileSync('output/input3.scss', 'utf8')).toBe('h3 { color: green }');
+      expect(readFileSync('output/d1.scss', 'utf8')).toBe('.d1 { color: yellow }');
+      done();
+    });
+  }));
+
+  test('copies and renames files, using --up:1 option and rename callback, from subfolders but keeps .css extension', () => new Promise((done: any) => {
+    // Setup: create input files in subfolders
+    createDir('input/sub1');
+    createDir('input/sub2/deep1');
+    writeFileSync('input/root.css', '.root { color: black }');
+    writeFileSync('input/sub1/input1.css', 'h1 { color: red }');
+    writeFileSync('input/sub2/input2.css', 'h2 { color: blue }');
+    writeFileSync('input/sub2/input3.css', 'h3 { color: green }');
+    writeFileSync('input/sub2/deep1/d1.css', '.d1 { color: yellow }');
+
+    copyfiles(['input/**/*.css', 'output'], {
+      up: 1,
+      rename: (_src, dest) => dest.replace(/([^/\\]+)\.css$/, 'renamed-$1.css')
+    }, (err) => {
+      expect(err).toBeUndefined();
+      expect(readFileSync('output/renamed-root.css', 'utf8')).toBe('.root { color: black }');
+      expect(readFileSync('output/sub1/renamed-input1.css', 'utf8')).toBe('h1 { color: red }');
+      expect(readFileSync('output/sub2/renamed-input2.css', 'utf8')).toBe('h2 { color: blue }');
+      expect(readFileSync('output/sub2/renamed-input3.css', 'utf8')).toBe('h3 { color: green }');
+      expect(readFileSync('output/sub2/deep1/renamed-d1.css', 'utf8')).toBe('.d1 { color: yellow }');
+      done();
+    });
+  }));
+
+  test('throws with rename glob and up 2', () => new Promise((done: any) => {
+    // Setup: create input files in subfolders
+    createDir('input/sub1');
+    createDir('input/sub2/deep1');
+    writeFileSync('input/root.css', '.root { color: black }');
+    writeFileSync('input/sub1/input1.css', 'h1 { color: red }');
+    writeFileSync('input/sub2/input2.css', 'h2 { color: blue }');
+    writeFileSync('input/sub2/input3.css', 'h3 { color: green }');
+    writeFileSync('input/sub2/deep1/d1.css', '.d1 { color: yellow }');
+
+    copyfiles(['input/**/*.css', 'output/*.scss'], { up: 2 }, (err) => {
+      if (err) {
+        expect(err?.message).toBe(`Can't go up 2 levels from input (1 levels).`);
+        done();
+      }
     });
   }));
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ function getDestinationPath(
 ): string {
   const fileDir = dirname(inFile);
   const fileName = basename(inFile);
-  const srcExt = path.extname(fileName);
+  const srcExt = extname(fileName);
   const srcBase = fileName && srcExt ? fileName.slice(0, -srcExt.length) : fileName;
   const upCount = options.up || 0;
 
@@ -67,12 +67,12 @@ function getDestinationPath(
     const baseOutDir = outDir.replace(/[*][^\\\/]*$/, '');
     let dest: string;
     if (options.flat || upCount === true) {
-      dest = path.join(baseOutDir, path.basename(finalDestFileName));
+      dest = join(baseOutDir, basename(finalDestFileName));
     } else if (upCount) {
       const upPath = dealWith(fileDir, upCount);
-      dest = path.join(baseOutDir, upPath, path.basename(finalDestFileName));
+      dest = join(baseOutDir, upPath, basename(finalDestFileName));
     } else {
-      dest = path.join(baseOutDir, fileDir, path.basename(finalDestFileName));
+      dest = join(baseOutDir, fileDir, basename(finalDestFileName));
     }
     return callRenameWhenDefined(inFile, dest, options);
   }
@@ -201,12 +201,10 @@ export function copyfiles(paths: string[], options: CopyFileOptions, callback?: 
             console.log(`Files copied:   ${allFiles.length}`);
             console.timeEnd('Execution time');
           }
-          if (typeof cb === 'function') {
-            cb();
-          }
+          if (typeof cb === 'function') cb();
         }
       },
-      isSingleFile && isDestFile
+      isSingleFile && isDestFile // pass as single rename mode
     );
   });
 }
@@ -254,6 +252,7 @@ function copyFileStream(
   readStream.on('error', onceCallback);
   writeStream.on('error', onceCallback);
   writeStream.on('close', () => {
+    // Only execute callback if not already called by an error
     if (!called) {
       onceCallback();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,15 +63,10 @@ function getDestinationPath(
       destFileName += extname(outDir) || srcExt;
     }
     let dest: string;
-    if (options.flat) {
+    if (options.flat || upCount === true) {
       dest = path.join(outDir.replace(/[*][^\\\/]*$/, ''), path.basename(destFileName));
-    } else if (upCount && upCount !== true) {
+    } else if (upCount) {
       const upPath = dealWith(fileDir, upCount);
-      dest = path.join(outDir.replace(/[*][^\\\/]*$/, ''), upPath, path.basename(destFileName));
-    } else if (upCount === true) {
-      // Remove the first directory from fileDir (i.e., 'input')
-      const parts = fileDir.split(path.sep).filter(Boolean);
-      const upPath = parts.length > 1 ? parts.slice(1).join(path.sep) : '';
       dest = path.join(outDir.replace(/[*][^\\\/]*$/, ''), upPath, path.basename(destFileName));
     } else {
       dest = path.join(outDir.replace(/[*][^\\\/]*$/, ''), fileDir, path.basename(destFileName));

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,28 +1,34 @@
 export interface CopyFileOptions {
-  /** include files & directories begining with a dot (.) */
+  /** Include files & directories beginning with a dot (.) */
   all?: boolean;
 
-  /** throw error if nothing is copied */
+  /** Throw error if nothing is copied */
   error?: boolean;
 
-  /** pattern or glob to exclude (may be passed multiple times) */
+  /** Pattern or glob to exclude files (may be passed multiple times in the CLI) */
   exclude?: string | string[];
 
-  /** flatten the output */
+  /** Flatten the output */
   flat?: boolean;
 
-  /** follow symbolink links */
+  /** Follow symbolic link links */
   follow?: boolean;
 
-  /** show statistics after execution (execution time + file count) */
+  /** Show statistics after execution (execution time + file count) */
   stat?: boolean;
 
-  /** slice a path off the bottom of the paths */
+  /**
+   * Slice a path off the bottom of the paths.
+   * Note: when is assigned with `up: true`, it is equivalent to `flat: true`
+   */
   up?: boolean | number;
 
-  /** print more information to console */
+  /** Print files being copied to the console */
   verbose?: boolean;
 
-  /** callback to run when the execution finished or an error occured */
-  callback?: (e?: Error) => void
+  /** Callback to run when the execution finished or an error occured */
+  callback?: (e?: Error) => void;
+
+  /** Callback to transform the destination filename(s) */
+  rename?: (src: string, dest: string) => string;
 }


### PR DESCRIPTION
**Example: Change extension to `.scss` using CLI**

```bash
copyfiles "input/**/*.css" "output/*.scss"
```

This will copy:

- `input/foo.css` → `output/foo.scss`
- `input/bar/baz.css` → `output/bar/baz.scss`

or via `rename` callback

**Example: Change extension to `.scss` using a callback**

```js
import { copyfiles } from 'native-copyfiles';

copyfiles(['input/**/*.css', 'output'], {
  flat: true,
  rename: (src, dest) => dest.replace(/\.css$/, '.scss')
}, (err) => {
  // All files like input/foo.css → output/foo.scss
});
```