### PR TITLE
feat: add `--dry-run` option

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "editor.codeActionsOnSave":{
+    "source.organizeImports.biome": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@
 [![npm](https://img.shields.io/npm/dy/native-copyfiles)](https://www.npmjs.com/package/native-copyfiles)
 [![npm bundle size](https://img.shields.io/bundlephobia/minzip/native-copyfiles?color=success&label=gzip)](https://bundlephobia.com/result?p=native-copyfiles)
 
-## Copyfiles
-#### native-copyfiles
+## native-copyfiles
 
 Copy files easily via JavaScript or the CLI, it uses [tinyglobby](https://www.npmjs.com/package/tinyglobby) internally for glob patterns and [yargs](https://www.npmjs.com/package/yargs) for the CLI.
 
-The library is very similar to the [copyfiles](https://www.npmjs.com/package/copyfiles) package, it is however written with more native NodeJS code and less dependencies (3 instead of 7). The package options are the same (except for `--soft` which is not implemented), some new options were also added in this project here (see below).
+The library is very similar from the outside to the [copyfiles](https://www.npmjs.com/package/copyfiles) package, however its internal is quite different, it uses more native NodeJS code and less dependencies (3 instead of 7). The package options are the same (except for `--soft` which is not implemented), some new options were also added in this project here (see below).
 
-> Note: there is 1 major difference with `copyfiles`, any options must be provided as a suffix after the source/target directories command (the original project had them as prefix)<br>
+> Note: there is 1 noticeable difference with `copyfiles`, any options must be provided as a suffix after the source/target directories command (the original project had them as prefix).<br>
 > This mean calling: `copyfiles source target [options]` instead of `copyfiles [options] source target`
 
 ### Install
@@ -28,16 +27,17 @@ npm install native-copyfiles -D
   Usage: copyfiles inFile [more files ...] outDirectory [options]
 
   Options:
-    -u, --up       slice a path off the bottom of the paths                  [number]
-    -a, --all      include files & directories begining with a dot (.)       [boolean]
-    -f, --flat     flatten the output                                        [boolean]
-    -e, --exclude  pattern or glob to exclude (may be passed multiple times) [string|string[]]
-    -E, --error    throw error if nothing is copied                          [boolean]
-    -V, --verbose  print more information to console                         [boolean]
-    -F, --follow   follow symbolic links                                     [boolean]
-    -s, --stat     show statistics after execution (time + file count)       [boolean]
-    -v, --version  show version number                                       [boolean]
-    -h, --help     show help                                                 [boolean]
+    -u, --up       slice a path off the bottom of the paths                     [number]
+    -a, --all      include files & directories begining with a dot (.)          [boolean]
+    -d, --dry-run  show what would be copied, without actually copying anything [boolean]
+    -f, --flat     flatten the output                                           [boolean]
+    -e, --exclude  pattern or glob to exclude (may be passed multiple times)    [string|string[]]
+    -E, --error    throw error if nothing is copied                             [boolean]
+    -V, --verbose  print more information to console                            [boolean]
+    -F, --follow   follow symbolic links                                        [boolean]
+    -s, --stat     show statistics after execution (time + file count)          [boolean]
+    -v, --version  show version number                                          [boolean]
+    -h, --help     show help                                                    [boolean]
 ```
 
 > [!NOTE]
@@ -202,6 +202,7 @@ and finally the third and last argument is a callback function which is executed
     up: number,         // slice a path off the bottom of the paths
     exclude: string,    // exclude pattern
     all: bool,	        // include dot files
+    dryRun: bool,       // show what would be copied, without actually copying anything
     follow: bool,       // follow symlinked directories when expanding ** patterns
     error: bool         // raise errors if no files copied
     stat: bool          // show statistics after execution (time + file count)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "biome:lint:write": "biome lint --write ./src",
     "biome:format:check": "biome format ./src",
     "biome:format:write": "biome format --write ./src",
-    "preview:copy": "node dist/cli.js test-copyin test-copyout --flat --verbose",
+    "preview:copy": "node dist/cli.js test-copyin test-copyout --dry-run --flat --stat",
     "preview:release": "release-it --only-version --dry-run",
     "release": "release-it --only-version",
     "test": "vitest --watch --config ./vitest.config.mts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,11 @@ const argv = cli
     type: 'boolean',
     description: 'include files & directories begining with a dot (.)',
   })
+  .option('dryRun', {
+    alias: 'd',
+    type: 'boolean',
+    description: 'Show what would be copied, but do not actually copy any files',
+  })
   .option('error', {
     alias: 'E',
     type: 'boolean',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,9 @@ export interface CopyFileOptions {
   /** Include files & directories beginning with a dot (.) */
   all?: boolean;
 
+  /** Show what would be copied, but do not actually copy any files */
+  dryRun?: boolean;
+
   /** Throw error if nothing is copied */
   error?: boolean;
 


### PR DESCRIPTION
- show what would be copied, without actually copying anything
- use `--dry-run` (CLI) or `options.dryRun` (API)

![image](https://github.com/user-attachments/assets/343d49c4-b93d-4402-af01-be81fdd52302)
